### PR TITLE
bugfix: interface conversion: interface {} is *sql.RawBytes, not *sql…

### DIFF
--- a/database/conn_info_test.go
+++ b/database/conn_info_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func Test_GetConnInfo(t *testing.T) {
-	userName := "test"
-	passwd := "test123456"
+	userName := "test_user"
+	passwd := "123456test"
 	ip := "localhost"
 	port := 3306
 	connStr := fmt.Sprintf("%s:%s@tcp(%s:%d)/", userName, passwd, ip, port)

--- a/database/row_in_map.go
+++ b/database/row_in_map.go
@@ -1005,11 +1005,6 @@ func createReceivers(fields []Field) (receivers []interface{}) {
 				var val sql.RawBytes
 				receivers = append(receivers, &val)
 			}
-		case "blob":
-			{
-				var val sql.RawBytes
-				receivers = append(receivers, &val)
-			}
 		default:
 			var val sql.NullString
 			receivers = append(receivers, &val)
@@ -1092,7 +1087,7 @@ func getRecordInMapFromReceiver(receiver []interface{}, fields []Field) (record 
 					record[field.Name] = nullVal.Bool
 				}
 			}
-		case "blob":
+		case "binary":
 			{
 				rawVal := value.(*sql.RawBytes)
 				record[field.Name] = nil
@@ -1190,7 +1185,7 @@ func getRecordInOrderedMapFromReceiver(receiver []interface{}, fields []Field) (
 					record.Set(field.Name, nullVal.Bool)
 				}
 			}
-		case "blob":
+		case "binary":
 			{
 				rawVal := value.(*sql.RawBytes)
 				record.Set(field.Name, nil)
@@ -1233,11 +1228,11 @@ var columnTypeDict = map[string]string{
 	"INTEGER":    "int32",
 	"BIGINT":     "int64",
 	"BINARY":     "binary",
-	"VARBINARY":  "blob",
-	"BLOB":       "blob",
-	"TINYBLOB":   "blob",
-	"MEDIUMBLOB": "blob",
-	"LONGBLOB":   "blob",
+	"VARBINARY":  "binary",
+	"BLOB":       "binary",
+	"TINYBLOB":   "binary",
+	"MEDIUMBLOB": "binary",
+	"LONGBLOB":   "binary",
 	"TEXT":       "string",
 	"TINYTEXT":   "string",
 	"MEDIUMTEXT": "string",

--- a/database/row_in_slice.go
+++ b/database/row_in_slice.go
@@ -286,7 +286,7 @@ func getRecordFromReceiver(receiver []interface{}, fields []Field) (record []int
 					record[idx] = nullVal.Bool
 				}
 			}
-		case "blob", "binary":
+		case "binary":
 			{
 				rawVal := value.(*sql.RawBytes)
 				if rawVal != nil && *rawVal != nil {


### PR DESCRIPTION
问题：
修复查询 bug
panic: interface conversion: interface {} is *sql.RawBytes, not *sql.NullString

问题原因：
之前处理逻辑在有的地方没有处理 binary类型数据

处理方案：
将 MySQL中 blob和 binary类型数据统一为 binary类型进行处理